### PR TITLE
Specify files to be published

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,15 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  }
+  },
+  "files": [
+    "index.js",
+    "ember-cli-build.js",
+    "addon/",
+    "app/",
+    "blueprints/",
+    "config/",
+    "lib/",
+    "vendor/"
+  ]
 }


### PR DESCRIPTION
Avoid publishing files accidentally by white listing the ones we
actually want to send.