### PR TITLE
Add sharp workaround

### DIFF
--- a/lib/generate-icons.js
+++ b/lib/generate-icons.js
@@ -29,13 +29,30 @@ class GenerateIcons extends CachingWriter {
     const fileName = `${this.options.outputFileName}${size}.${this.options.convertTo}`;
     const outputPath = path.join(this.outputPath, fileName);
     const originalSvg = path.join(this.inputPaths[0], this.options.inputFilename);
-    let image = sharp(originalSvg).resize(size);
+    const image = this.getSharp(originalSvg);
+    image.resize(size);
     if (this.options.background) {
       image.flatten({ background: this.options.background });
     }
 
     return image.toFormat(this.options.convertTo).toFile(outputPath);
 
+  }
+  /**
+   * There is an issue in the way sharp processes SVGs on OSX
+   * This is a workaround based on https://github.com/lovell/sharp/issues/1593#issuecomment-491171982
+   */
+  getSharp(path) {
+    sharp(
+      Buffer.from(
+        `<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" /></svg>`,
+        'utf-8'
+      )
+    ).metadata().catch(() => {
+      //do nothing
+    });
+
+    return sharp(path);
   }
 }
 


### PR DESCRIPTION
On OSX builds intermittently fail due to some deep problem with libvips
and sharp. They only seem to fail the first time sharp is run so this is
a way to warmup sharp.