### PR TITLE
Skip Git Checks on Publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: pnpm install --ignore-scripts
       - name: publish
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
We're publishing off of master here so we need to skip the checks to make pnpm happy.